### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ powa-collector (1.2.0-2) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 21 Sep 2022 12:19:55 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+powa-collector (1.2.0-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 21 Sep 2022 12:19:55 -0000
+
 powa-collector (1.2.0-1) unstable; urgency=medium
 
   * New upstream version.

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends:
  python3,
  python3-psycopg2,
  python3-setuptools,
-Standards-Version: 4.6.0
+Standards-Version: 4.6.1
 Rules-Requires-Root: no
 Homepage: https://github.com/powa-team/powa-collector
 Vcs-Browser: https://github.com/powa-team/powa-collector

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/powa-team/powa-collector/issues
+Bug-Submit: https://github.com/powa-team/powa-collector/issues/new
+Repository: https://github.com/powa-team/powa-collector.git
+Repository-Browse: https://github.com/powa-team/powa-collector


### PR DESCRIPTION
Fix some issues reported by lintian

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))

* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/powa-collector/b1318bf7-6f0e-431f-9710-98756793be31.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/b1318bf7-6f0e-431f-9710-98756793be31/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/b1318bf7-6f0e-431f-9710-98756793be31/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/b1318bf7-6f0e-431f-9710-98756793be31/diffoscope)).
