### PR TITLE
Make use of temp tables

### DIFF
--- a/powa_collector/powa_worker.py
+++ b/powa_collector/powa_worker.py
@@ -602,7 +602,7 @@ class PowaThread (threading.Thread):
 
             errors.extend(copy_remote_data_to_repo(self, kind_name, data_src,
                                                    data_src_sql, ins,
-                                                   target_tbl_name,
+                                                   target_tbl_name, srvid,
                                                    cleanup_sql))
 
         data_src.close()
@@ -781,7 +781,7 @@ class PowaThread (threading.Thread):
 
             errors.extend(copy_remote_data_to_repo(self, db_module, data_src,
                                                    data_src_sql, ins,
-                                                   tmp_table))
+                                                   tmp_table, srvid))
 
         # then process the outdated catalogs on that databasr
         for row in db_cat_queries:
@@ -809,7 +809,7 @@ class PowaThread (threading.Thread):
 
             errors.extend(copy_remote_data_to_repo(self, catname, data_src,
                                                    data_src_sql, ins,
-                                                   tmp_table))
+                                                   tmp_table, srvid))
 
         data_src.close()
         dbconn.close()


### PR DESCRIPTION
Closes #23

If this goes according to plan, then we can just slightly patch  powa archivist to DELETE FROM ONLY to not waste time with those temp tables. They'll just get purged at disconnection

The only issue I see that this could bring is that we'll have lots of distinct queryids on the collector itself, if we decide to manage via powa

We could make disconnection from the database optional so that we can keep the temp tables active, but I really think this temp table mechanism isn't a big price to pay for the dramatic IO reduction it should bring

Anyway, comments are welcome