### PR TITLE
fix: Properly detect and report missing extensions

### DIFF
--- a/powa_collector/snapshot.py
+++ b/powa_collector/snapshot.py
@@ -78,10 +78,20 @@ def get_global_tmp_name(schema, src_fct):
 
 
 def get_nsp(conn, external, module):
+    """
+    Returns the given module schema.
+    If "external" is true, then it's an external extension so returns its
+    associated schema.
+    If "external" is false then it's an internal module so return the powa
+    extension schema instead.
+
+    Returns None if the module is not found.  Caller is responsible for
+    reporting an appropriate error in that case.
+    """
     if external:
-        return conn._nsps[module]
+        return conn._nsps.get(module, None)
     else:
-        return conn._nsps['powa']
+        return conn._nsps.get('powa', None)
 
 def copy_remote_data_to_repo(cls, data_name,
                         data_src, data_src_sql, data_ins, target_tbl_name,


### PR DESCRIPTION
Doing an extension remote snapshot relies on the extension being installed both on the remote server but also on the repository server.  If the extension is missing on either side the collector will currently fail with an obscure error about a missing key when trying to resolve the schema the extension is installed in.  We now properly check whether we found a schema for the wanted extension, and if not report a proper error.

Thanks to github users jw1u1 and rafaelorafaelo who both reported the problem.