### PR TITLE
Fix stuck worker thread issue when saving extension versions

### DIFF
--- a/powa_collector/powa_worker.py
+++ b/powa_collector/powa_worker.py
@@ -252,6 +252,9 @@ class PowaThread (threading.Thread):
                                     + "hypopg: %s" % (e))
                 self.__repo_conn.rollback()
 
+        cur.close()
+        self.__remote_conn.commit()
+        rep_cur.close()
         self.__disconnect_repo()
 
     def __check_powa(self):


### PR DESCRIPTION
As seen in issue #40, worker threads can sometime get stuck in "idle in transaction" state.  This seems to only happen occasionally and with a somewhat high number of remote servers.

Ensuring that all cursors and the transacton on the remote server conneection is closed when saving the extension version seems to fix the problem, as investigated by Chris Gooch who also wrote the patch.

It's still unclear to me why this would only sporadically happen, but there is no harm in doing this cleanup.